### PR TITLE
Remove hash do css modules e adiciona namespaces

### DIFF
--- a/internals/webpack/webpack.config.js
+++ b/internals/webpack/webpack.config.js
@@ -64,7 +64,7 @@ const baseConfig = {
               options: {
                 modules: true,
                 importLoaders: true,
-                localIdentName: '[name]_[local]_[hash:base64:5]',
+                localIdentName: 'grm-[name]__[local]',
                 minimize: true,
                 sourceMap: false
               }

--- a/internals/webpack/webpack.dev.config.js
+++ b/internals/webpack/webpack.dev.config.js
@@ -63,7 +63,7 @@ const baseConfig = {
             options: {
               modules: true,
               importLoaders: true,
-              localIdentName: '[name]_[local]_[hash:base64:5]'
+              localIdentName: 'grm-[name]__[local]',
             }
           },
           {


### PR DESCRIPTION
De acordo com o que conversamos, removi o hash do css modules e acrescentei um "namespace" `grm-` referente ao grimório, assim, evitamos que estilos de fora sobrescrevam o nosso sem querer e garantimos a modularização do nosso css mesmo sem o hash com a estrutura `grm-[name]__[local]`!