### PR TITLE
Retira o hash no babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -49,7 +49,7 @@
         "@babel/plugin-proposal-export-namespace-from",
         ["css-modules-transform", {
           "preprocessCss": "./internals/css-modules-transform.js",
-          "generateScopedName": "[name]_[local]_[hash:base64:5]",
+          "generateScopedName": "grm-[name]__[local]",
           "extensions": [".styl"]
         }]
       ],


### PR DESCRIPTION
Quando fui gerar uma nova versão para carregar no b2wads, percebi que o css não carregava. Verificando o arquivo do babel, o hash ainda permanecia na parte de plugins, e na hora da transpilação  os arquivos permaneciam com o hash. Esse pr altera para o "novo padrão" do webpack.