### PR TITLE
Resolve bug do svg-react-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.2",
-    "svg-react-loader": "0.4.5",
     "webpack": "3.5.2",
     "webpack-bundle-analyzer": "3.0.3"
   },
@@ -107,7 +106,8 @@
     "react": "16.8.6",
     "react-css-modules": "4.7.2",
     "react-dates": "18.2.2",
-    "react-dom": "16.8.6"
+    "react-dom": "16.8.6",
+    "svg-react-loader": "0.4.5"
   },
   "jest": {
     "testURL": "http://localhost",


### PR DESCRIPTION
Porque o `svg-react-loader` não estava nas dependencias do grimorio, ele não era instalado no ato da instalação do tema e isso causava um erro na hora de importar os componentes.