### PR TITLE
style: corrige bug nas bordas dos inputs com validação

### DIFF
--- a/source/components/form/elements/form-control.styl
+++ b/source/components/form/elements/form-control.styl
@@ -303,6 +303,8 @@ Form Control Component
   & .form-addon {
     background: $c-success;
     border-color: $c-success;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
   }
 
   & .form-field, & .form-control {
@@ -318,6 +320,8 @@ Form Control Component
   & .form-addon {
     background: $c-warning;
     border-color: $c-warning;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
   }
 
   & .form-field, & .form-control {
@@ -333,6 +337,8 @@ Form Control Component
   & .form-addon {
     background: $c-error;
     border-color: $c-error;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
   }
 
   & .form-field, & .form-control {

--- a/source/components/form/elements/form-control.styl
+++ b/source/components/form/elements/form-control.styl
@@ -301,10 +301,7 @@ Form Control Component
   }
 
   & .form-addon {
-    background: $c-success;
     border-color: $c-success;
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
   }
 
   & .form-field, & .form-control {
@@ -318,10 +315,7 @@ Form Control Component
   }
 
   & .form-addon {
-    background: $c-warning;
     border-color: $c-warning;
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
   }
 
   & .form-field, & .form-control {
@@ -335,10 +329,7 @@ Form Control Component
   }
 
   & .form-addon {
-    background: $c-error;
     border-color: $c-error;
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
   }
 
   & .form-field, & .form-control {


### PR DESCRIPTION
Fixes #95 

Implementei um border-radius de 4px nas duas extremidades de cima para que elas fiquem atrás das extremidades do input, o que corrige o bug.

![bug-fix](https://user-images.githubusercontent.com/13375865/69471863-fa089f00-0d82-11ea-85a5-38b527eed95f.png)
